### PR TITLE
Add permanent axis display option + display all mesh types

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,6 +10,7 @@ bl_info = {
 
 import bpy
 from .color_by_axis import CBA_OT_Color_by_Axis
+from .color_by_axis_permanent import CBA_Permanent
 from .error_message import CBA_OT_ErrorMessage
 from .ui import CBA_PT_Main_Panel
 
@@ -32,13 +33,19 @@ def register():
 
     bpy.types.Scene.axis_type = bpy.props.EnumProperty(items=items, name="Axis type", description="Choose axis type that will affect the overlay")
     bpy.types.Scene.axis_ref = bpy.props.PointerProperty(type=bpy.types.Object)
-    
+    bpy.types.Scene.draw_permanent = bpy.props.BoolProperty(name="Always ON")
+    CBA_Permanent.draw_handler = bpy.types.SpaceView3D.draw_handler_add(
+        CBA_Permanent.draw, (), "WINDOW", "POST_VIEW"
+    )
+
 
 def unregister():
     from bpy.utils import unregister_class
     for cls in classes:
         unregister_class(cls)
 
+    bpy.types.SpaceView3D.draw_handler_remove(CBA_Permanent.draw_handler, "WINDOW")
+    del bpy.types.Scene.draw_permanent
     del bpy.types.Scene.axis_type
     del bpy.types.Scene.axis_ref
 

--- a/color_by_axis_permanent.py
+++ b/color_by_axis_permanent.py
@@ -1,0 +1,65 @@
+import bpy
+import bmesh
+import bgl
+import gpu
+import mathutils
+from gpu_extras.batch import batch_for_shader
+
+
+class CBA_Permanent:
+    draw_handler = None
+
+    @staticmethod
+    def get_verts():
+        context = bpy.context
+        axis_type = context.scene.axis_type
+        depsgraph = context.evaluated_depsgraph_get()
+        verts = [[], [], []]
+
+        def equals(c1, c2, precision=4):
+            return abs(c1 - c2) < 10 ** (-precision)
+
+        for o in context.selected_objects:
+            if o.type not in ("MESH", "CURVE", "SURFACE", "FONT", "META"):
+                continue
+            if context.mode == "EDIT_MESH":
+                bm = bmesh.from_edit_mesh(o.data)
+            else:
+                object_eval = o.evaluated_get(depsgraph)
+                mesh_eval = object_eval.to_mesh()
+                bm = bmesh.new()
+                bm.from_mesh(mesh_eval)
+
+            axis_reference = context.scene.axis_ref
+            matrix_world = o.matrix_world
+            matrix_calc = mathutils.Matrix.Identity(4)
+            if axis_type == "REFERENCE" and axis_reference:
+                matrix_calc = axis_reference.matrix_world
+            elif axis_type == "GLOBAL":
+                matrix_calc = matrix_world
+
+            for e in bm.edges:
+                v1_global = matrix_world @ e.verts[0].co
+                v2_global = matrix_world @ e.verts[1].co
+                v1 = matrix_calc @ e.verts[0].co
+                v2 = matrix_calc @ e.verts[1].co
+                for i, axis in enumerate(((1, 2), (0, 2), (0, 1))):
+                    if equals(v1[axis[0]], v2[axis[0]]) and equals(v1[axis[1]], v2[axis[1]]):
+                        verts[i].append(v1_global)
+                        verts[i].append(v2_global)
+
+        return verts
+
+    @staticmethod
+    def draw():
+        if not hasattr(bpy.context.scene, "draw_permanent") or not bpy.context.scene.draw_permanent:
+            return
+        bgl.glLineWidth(2)
+        verts_axes = CBA_Permanent.get_verts()
+        for i, color in enumerate(((1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1))):
+            coords = verts_axes[i]
+            shader = gpu.shader.from_builtin("3D_UNIFORM_COLOR")
+            batch = batch_for_shader(shader, "LINES", {"pos": coords})
+            shader.bind()
+            shader.uniform_float("color", color)
+            batch.draw(shader)

--- a/ui.py
+++ b/ui.py
@@ -31,6 +31,7 @@ class CBA_PT_Main_Panel(bpy.types.Panel):
         col2 = layout.column()
         col2.label(text="Reference Object")
         col2.prop_search(scene, 'axis_ref', scene, 'objects', text="")
+        layout.prop(scene, "draw_permanent", toggle=True)
 
         # Use the axis_type chosen in the UI as an input to the operator
         color_by_axis_button.axis_type = scene.axis_type


### PR DESCRIPTION
I thought it would be a nice exercise to try and add functionality to your very nice work. I hope you're okay with that, I tried not to change things outside of the new file too much. I tried to optimise redundant code in the verts selection part but I may have missed things.

It adds a permanent handler and a toggle in the addon panel to display colored wires for every selected object in any mode

Supports Curves, Meta objects, surfaces, texts

![image](https://user-images.githubusercontent.com/25156105/162720160-2fcc751f-9516-4d23-8bd6-bfa1902145ac.png)

Toggle on or off with a button in the interface.

![image](https://user-images.githubusercontent.com/25156105/162720249-5c920968-3460-4672-8a0c-18064ff3dee9.png)

![capture](https://user-images.githubusercontent.com/25156105/162720642-ce33fd24-1225-4035-8534-d7a2032b9e8f.gif)

